### PR TITLE
hacs and hassfest actions to validate commits

### DIFF
--- a/.github/workflows/hacsaction.yaml
+++ b/.github/workflows/hacsaction.yaml
@@ -1,0 +1,16 @@
+name: HACS Action
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  hacs:
+    name: HACS Action
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v2"
+      - name: HACS Action
+        uses: "hacs/action@main"
+        with:
+          category: "integration"

--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -1,0 +1,12 @@
+name: Validate with hassfest
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  validate:
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v2"
+      - uses: home-assistant/actions/hassfest@master


### PR DESCRIPTION
Added HACS and hassfest action.

HACS will check against the HACS codebase to ensure that the integration is compliant with the format needs for HACS, and alert you when committing changes that may cause validation issues with being published in HACS

hassfest will run against the Home Assistant repository, to ensure that the integration is complaint with HA's latest standards and requirements for integrations, advising you of anything that may cause it to throw and error or warning due to compatibility or depricated reasons. It will also glance at the Beta branches of HA, to give you a warning about future changes coming that may cause issues as well.